### PR TITLE
Patch. Was accidently published with the dist folder.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,3 +33,6 @@
 
 4.0.0 April, 2019
 - Add tests for correspondence information. Remove babel build.
+
+4.0.1 April, 2019
+- Remove dist from published data.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chargehound",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Automatically fight disputes",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
I removed the need for the dist folder, but I also removed the task that would delete the dist folder before rebuilding and publishing the package, so I accidentally published the old dist folder that I had locally.