### PR TITLE
Node 22 compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,3 +46,7 @@
 
 6.0.0 Sept, 2023
   - Force all requests to go through HTTPS
+
+7.0.0 Map, 2025
+  - Added Node 22 support
+  - Improved Disputes PUT request socket handling

--- a/lib/api-requestor.js
+++ b/lib/api-requestor.js
@@ -58,7 +58,8 @@ module.exports = class ApiRequestor {
         path: requestUrl.pathname + requestUrl.search,
         method: spec.method.toUpperCase(),
         headers: this.getHeaders(!!spec.data),
-        auth: `${this.getApiKey()}:`
+        auth: `${this.getApiKey()}:`,
+        rejectUnauthorized: true
       }
 
       if (this._chargehound.options.port) {
@@ -66,7 +67,6 @@ module.exports = class ApiRequestor {
       }
 
       const req = https.request(reqOpts).setTimeout(this.getTimeout())
-      const connectEv = 'secureConnect'
 
       req.on('timeout', function () {
         req.abort()
@@ -77,13 +77,19 @@ module.exports = class ApiRequestor {
       })
 
       req.on('socket', function (socket) {
-        socket.on(connectEv, function () {
+        socket.on('connect', function () {
           if (spec.data) {
             req.write(JSON.stringify(spec.data))
           }
           req.end()
         })
       })
+
+      // Ensure the request is sent even if the event is not triggered
+      if (spec.data) {
+        req.write(JSON.stringify(spec.data))
+      }
+      req.end()
 
       req.on('response', function (res) {
         let response = ''

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chargehound",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Automatically fight disputes",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
From Node 22 onwards, there is failure while calling PUT request:

The issue arises because of changes in the behavior of the  module in Node.js 22 compared to Node.js 16. Specifically, the secureConnect event may not be emitted as expected in Node.js 22 due to stricter handling of TLS connections or changes in the event lifecycle.

In this change, We are using the `connect` event Instead of `secureConnect` on socket connection while calling `https.request`.